### PR TITLE
asyncpgsa 0.27.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,21 +1,17 @@
 {% set name = "asyncpgsa" %}
 {% set version = "0.27.1" %}
-{% set hash_type = "sha256" %}
-{% set hash_value = "32e9ad376caf969d606800a977f044dda2ed946eb10f3c87dac2690ae897f6aa" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  {{ hash_type }}: {{ hash_value }}
+  sha256: 32e9ad376caf969d606800a977f044dda2ed946eb10f3c87dac2690ae897f6aa
 
 build:
-  number: 0
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv "
-  skip: True  # [py2k]
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -24,16 +20,20 @@ requirements:
     # Project imports itself to find out version during build
     # time which results into importing runtime dependencies
     - asyncpg
-    - sqlalchemy
+    - sqlalchemy <2
   run:
     - python
-    - asyncpg
-    - sqlalchemy
+    - asyncpg >=0.22.0
+    - sqlalchemy <2
 
 test:
   imports:
     - asyncpgsa
     - asyncpgsa.testing
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/canopytax/asyncpgsa
@@ -47,8 +47,7 @@ about:
     implementation of PostgreSQL server binary protocol for use with Python's
     asyncio framework.
   dev_url: https://github.com/CanopyTax/asyncpgsa
-  doc_url: http://asyncpgsa.readthedocs.io
-  doc_source_url: https://github.com/CanopyTax/asyncpgsa/blob/master/docs/index.rst
+  doc_url: https://asyncpgsa.readthedocs.io
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Current package info**


| Channel | Downloads | Version | Platforms | License |
| --- | --- | --- | --- | --- |
| defaults | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/asyncpgsa.svg)](https://anaconda.org/main/asyncpgsa) | [![Conda Version](https://img.shields.io/conda/vn/main/asyncpgsa.svg)](https://anaconda.org/main/asyncpgsa) | [![Conda Platforms](https://img.shields.io/conda/pn/main/asyncpgsa.svg)](https://anaconda.org/main/asyncpgsa) | ![Conda License](https://img.shields.io/conda/l/main/asyncpgsa) |

License: https://github.com/CanopyTax/asyncpgsa/blob/master/LICENSE
Requirements: https://github.com/CanopyTax/asyncpgsa/blob/b2445202a2484494d88fc5c484d5296991973d78/setup.py

Actions:
1. Clean up the recipe
2. Increase the build number
3. Fix sqlalchemy pin <2, see https://github.com/CanopyTax/asyncpgsa/issues/116
4. Add pin for asyncpg
5. Add pip check


Notes:
- We rebuild this package because of its incompatibility with **sqlalchemy 2.x.x**